### PR TITLE
change "/" to path.sep for cross-platform paths, fixes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function (options) {
         var files = fs.readdirSync(dir);
 
         for (var i in files) {
-            var name = dir + '/' + files[i];
+            var name = dir + path.sep + files[i];
             if (fs.statSync(name).isDirectory()){
                 getFiles(name, files_);
             } else {
@@ -70,17 +70,17 @@ module.exports = function (options) {
      */
     function generateTemplate(templatePath) {
         var absoluteTemplatePath = path.resolve(templatePath);
-        var dest = options.wrapInFolder ? options.componentName + "/" : "";
+        var dest = options.wrapInFolder ? options.componentName + path.sep : "";
 
         // check if the file need a specific location
         if (options.dest) {
-            dest = options.dest + "/" + dest;
+            dest = options.dest + path.sep + dest;
         }
 
         fs.readFile(absoluteTemplatePath, 'utf8', function(err, data) {
             if (err) throw err;
-            var templateFilename = absoluteTemplatePath.replace(templateAbsolutePath + "/", "");
-            var templatePathWithoutFileName = templateFilename.substring(0, templateFilename.lastIndexOf("/"));
+            var templateFilename = absoluteTemplatePath.replace(templateAbsolutePath + path.sep, "");
+            var templatePathWithoutFileName = templateFilename.substring(0, templateFilename.lastIndexOf(path.sep));
             var fileExt = templateFilename ? templateFilename.split('.').pop() : '';
 
             mkdirp(dest + templatePathWithoutFileName, function () {


### PR DESCRIPTION
By using `path.sep` instead of `"/"` we can fix the issue with paths not working in Windows. 
`path.sep` will use either `"/"` or `"\"` depending on the filesystem, so this solves Issue #1.