### PR TITLE
Updated path-complete-extname

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mkdirp": "0.5.1",
     "inquirer": "^0.4.1",
     "lodash": "4.17.4",
-    "path-complete-extname": "^0.1.0",
+    "path-complete-extname": "^1.0.0",
     "underscore.string": "^2.3.3"
   }
 }


### PR DESCRIPTION
I just recently released [path-complete-extname@1.0.0](https://github.com/ruyadorno/path-complete-extname/releases/tag/v1.0.0) in order to mitigate a [vulnerability report](https://mobile.twitter.com/ruyadorno/status/971478590532431872) that traces back to the original **node@0.10** implementation in which the module was based on.

The solution was to rewrite the module basing it in the [current node implementation](https://github.com/nodejs/node/tree/v9.6.1/lib/path.js) and publish a new major version. I'm reaching out to all libraries described on [npm dependencies list](https://www.npmjs.com/browse/depended/path-complete-extname) to make sure they can all get the new patched version as soon as possible.

I decided for a major release in order to be able to properly follow [semver](https://semver.org/) from now on and to properly reflect the stable state of the library that has been around for 4 years 😊 

Let me know if there are any concerns and please feel free to [review all the code changes](https://github.com/ruyadorno/path-complete-extname/pull/1/files).

Best,

Ruy Adorno